### PR TITLE
Type conversions

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -170,6 +170,9 @@ package main
 func main() {
   []a.b(c.d)
   ([]a.b)(c.d)
+  // These type conversions cannot be distinguished from call expressions
+  T(x)
+  (*Point)(p)
   e.f(g)
   (e.f)(g)
 }
@@ -185,11 +188,18 @@ func main() {
     (type_conversion_expression
       (parenthesized_type (slice_type (qualified_type (package_identifier) (type_identifier))))
       (selector_expression (identifier) (field_identifier)))
+    (comment)
+    (call_expression
+      (identifier) (identifier))
+    (call_expression
+      (parenthesized_expression
+        (unary_expression (identifier))) (identifier))
     (call_expression
       (selector_expression (identifier) (field_identifier))
       (identifier))
     (call_expression
-      (parenthesized_expression (selector_expression (identifier) (field_identifier)))
+      (parenthesized_expression
+        (selector_expression (identifier) (field_identifier)))
       (identifier)))))
 
 ============================================


### PR DESCRIPTION
@maxbrunsfeld I think this is undecidable, but I've added two test cases that illustrate a problem I see with identifying type conversions from call expressions.

According to the Go language reference, the test cases I've added should be parsed as type conversions. I don't see a way for us to do that in tree-sitter without having a symbol table of known types when parsing a file.

Opening this because I think it's worth signaling in the tests that we today regard common type conversion expressions in Go as call expressions, and to verify this is an undecidable problem.