### PR TITLE
add iota identifier

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6438,6 +6438,10 @@
       "type": "STRING",
       "value": "false"
     },
+    "iota": {
+      "type": "STRING",
+      "value": "iota"
+    },
     "comment": {
       "type": "TOKEN",
       "content": {


### PR DESCRIPTION
Hi! Not sure if this is everything that is needed, but I haven't been able to syntax highlight the `iota` value using tree-sitter-go and it looked like it was just missing from the grammar.