### PR TITLE
Update to only highlight var declarations

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -19,7 +19,10 @@
 
 (type_identifier) @type
 (field_identifier) @property
-(identifier) @variable
+(short_var_declaration left: (expression_list (identifier) @variable))
+(var_declaration (var_spec name: (identifier) @variable))
+(parameter_declaration name: (identifier) @variable)
+(const_declaration (const_spec name: (identifier) @variable))
 
 ; Operators
 


### PR DESCRIPTION
See https://github.com/ubolonton/emacs-tree-sitter/issues/155 for context
Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
