### PR TITLE
adding make support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ package-lock.json
 examples/go
 examples/moby
 target
+
+*.a
+*.dylib
+*.so
+*.o

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ OBJ := $(addsuffix .o,$(basename $(SRC)))
 SONAME_MAJOR := 0
 SONAME_MINOR := 0
 
-CPPFLAGS ?= -O3 -Wall -Wextra -Werror
-override CFLAGS += -std=gnu99
-override CPPFLAGS += -fPIC
+CFLAGS ?= -O3 -Wall -Wextra -Werror
+CXXFLAGS ?= -O3 -Wall -Wextra -Werror
+override CFLAGS += -std=gnu99 -fPIC
+override CXXFLAGS += -fPIC
 
 # OS-specific bits
 ifeq ($(shell uname),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+VERSION := 0.19.1
+
+# install directory layout
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR ?= $(PREFIX)/lib
+PCLIBDIR ?= $(LIBDIR)/pkgconfig
+
+# collect C++ sources, and link if necessary
+CPPSRC := $(wildcard src/*.cc)
+
+ifeq (, $(CPPSRC))
+	ADDITIONALLIBS := 
+else
+	ADDITIONALLIBS := -lc++
+endif
+
+# collect sources
+SRC := $(wildcard src/*.c)
+SRC += $(CPPSRC)
+OBJ := $(addsuffix .o,$(basename $(SRC)))
+
+# ABI versioning
+SONAME_MAJOR := 0
+SONAME_MINOR := 0
+
+CPPFLAGS ?= -O3 -Wall -Wextra -Werror
+override CFLAGS += -std=gnu99
+override CPPFLAGS += -fPIC
+
+# OS-specific bits
+ifeq ($(shell uname),Darwin)
+	SOEXT = dylib
+	SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
+	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib
+	LINKSHARED += -dynamiclib -Wl,$(ADDITIONALLIBS),-install_name,$(LIBDIR)/libtree-sitter-go.$(SONAME_MAJOR).dylib
+else
+	SOEXT = so
+	SOEXTVER_MAJOR = so.$(SONAME_MAJOR)
+	SOEXTVER = so.$(SONAME_MAJOR).$(SONAME_MINOR)
+	LINKSHARED += -shared -Wl,$(ADDITIONALLIBS),-soname,libtree-sitter-go.so.$(SONAME_MAJOR)
+endif
+ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))
+	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
+endif
+				
+all: libtree-sitter-go.a libtree-sitter-go.$(SOEXTVER)
+
+libtree-sitter-go.a: $(OBJ)
+	$(AR) rcs $@ $^
+
+libtree-sitter-go.$(SOEXTVER): $(OBJ)
+	$(CC) $(LDFLAGS) $(LINKSHARED) $^ $(LDLIBS) -o $@
+	ln -sf $@ libtree-sitter-go.$(SOEXT)
+	ln -sf $@ libtree-sitter-go.$(SOEXTVER_MAJOR)
+
+install: all
+	install -d '$(DESTDIR)$(LIBDIR)'
+	install -m755 libtree-sitter-go.a '$(DESTDIR)$(LIBDIR)'/libtree-sitter-go.a
+	install -m755 libtree-sitter-go.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter-go.$(SOEXTVER)
+	ln -sf libtree-sitter-go.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter-go.$(SOEXTVER_MAJOR)
+	ln -sf libtree-sitter-go.$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/libtree-sitter-go.$(SOEXT)
+	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter
+	install -m644 bindings/c/go.h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/
+	install -d '$(DESTDIR)$(PCLIBDIR)'
+	sed -e 's|@LIBDIR@|$(LIBDIR)|;s|@INCLUDEDIR@|$(INCLUDEDIR)|;s|@VERSION@|$(VERSION)|' \
+	    -e 's|=$(PREFIX)|=$${prefix}|' \
+	    -e 's|@PREFIX@|$(PREFIX)|' \
+	    -e 's|@ADDITIONALLIBS@|$(ADDITIONALLIBS)|' \
+	    bindings/c/tree-sitter-go.pc.in > '$(DESTDIR)$(PCLIBDIR)'/tree-sitter-go.pc
+
+clean:
+	rm -f $(OBJ) libtree-sitter-go.a libtree-sitter-go.$(SOEXT) libtree-sitter-go.$(SOEXTVER_MAJOR) libtree-sitter-go.$(SOEXTVER)
+
+.PHONY: all install clean

--- a/bindings/c/go.h
+++ b/bindings/c/go.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_GO_H_
+#define TREE_SITTER_GO_H_
+
+#include <tree_sitter/parser.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_go();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_GO_H_

--- a/bindings/c/tree-sitter-go.pc.in
+++ b/bindings/c/tree-sitter-go.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@
+additionallibs=@ADDITIONALLIBS@
+
+Name: tree-sitter-go
+Description: Golang grammar for tree-sitter
+URL: https://github.com/tree-sitter/tree-sitter-go
+Version: @VERSION@
+Libs: -L${libdir} ${additionallibs} -ltree-sitter-go
+Cflags: -I${includedir}


### PR DESCRIPTION
This change adds a Makefile, and bindings to more easily build static/dynamic libraries for use in C-based languages. This is basically my first time making a Makefile. So, I just copied the one from the runtime and modified it. It was really close to what was needed.

This comes from some [discussion](https://github.com/tree-sitter/tree-sitter/issues/1488) I had in the main tree-sitter repo with @maxbrunsfeld.

One additional thing I want to bring up is that I also modify bindings.gyp. Specifically, I include the following:

      'xcode_settings': {
          'OTHER_CFLAGS': [
            "-arch x86_64",
            "-arch arm64",
            "-mmacosx-version-min=10.13",
          ],
          "OTHER_LDFLAGS":[
            "-mmacosx-version-min=10.13"
          ]
      },

This does two things. First, builds the library for both architectures supported by macOS. It also establishes a minimum OS version for the linker, which quiets warnings. (I suspect that tree-sitter is compatible with much earlier versions of macOS, but I've only tested down to 10.13.)

I'm not 100% sure this is possible to address via a Makefile, as I was unable to find a way to control these settings via environment variables. However, I know nothing about the npm build process, and just figuring out this part required a lot of Googling and experimentation. I just wanted to bring this up as it is related, and possibly something you'd prefer to address here.