### PR TITLE
Document reason for statements at top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ tree-sitter-go
 
 [![Build/test](https://github.com/tree-sitter/tree-sitter-go/actions/workflows/ci.yml/badge.svg)](https://github.com/tree-sitter/tree-sitter-go/actions/workflows/ci.yml)
 
-Golang grammar for [tree-sitter][].
+A [tree-sitter][] grammar for [Go](https://go.dev/ref/spec).
 
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter

--- a/grammar.js
+++ b/grammar.js
@@ -103,6 +103,8 @@ module.exports = grammar({
 
   rules: {
     source_file: $ => repeat(choice(
+      // Unlike a Go compiler, we accept statements at top-level to enable
+      // parsing of partial code snippets in documentation (see #63).
       seq($._statement, terminator),
       seq($._top_level_declaration, optional(terminator)),
     )),


### PR DESCRIPTION
Fixes #63 

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
