### PR TITLE
Structure Query

### DIFF
--- a/queries/structure.scm
+++ b/queries/structure.scm
@@ -1,0 +1,175 @@
+(import_declaration
+  "import" @structure.anchor
+  (import_spec_list
+    "(" @structure.open
+    ")" @structure.close
+  )
+)
+
+(function_declaration
+  "func" @structure.anchor
+  body: (block
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(function_declaration
+  (identifier) @structure.anchor
+  (parameter_list
+    "(" @structure.open
+    ("," @structure.separator (_))*
+    ")" @structure.close
+  )
+)
+
+(method_declaration
+  "func" @structure.anchor
+  body: (block
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(call_expression
+  function: (_) @structure.anchor
+  (argument_list
+    "(" @structure.open
+    ("," @structure.separator (_))*
+    ","? @structure.separator
+    ")" @structure.close
+  )
+)
+
+(composite_literal
+  type: (_) @structure.anchor
+  body: (literal_value
+    "{" @structure.open
+    ("," @structure.separator (_)?)*
+    "}" @structure.close
+  )
+)
+
+(literal_value
+ "{" @structure.anchor
+ ("," @structure.separator (_)?)*
+ "}" @structure.close
+)
+
+(if_statement
+  ["if" "else"] @structure.anchor
+  (block
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(if_statement
+  "else" @structure.anchor
+  (if_statement
+    "if"
+    (block
+      "{" @structure.open
+      "}" @structure.close
+    )
+  )
+)
+
+(expression_switch_statement
+  "switch" @structure.anchor
+  "{" @structure.open
+  "}" @structure.close
+)
+
+(expression_switch_statement
+  (expression_case
+    "case" @structure.anchor
+    ":" @structure.open
+  )
+  .
+  [
+    (expression_case "case" @structure.limit)
+    (default_case "default" @structure.limit)
+  ]
+)
+
+ (expression_switch_statement
+   (default_case "default" @structure.anchor)
+   "}" @structure.limit
+ )
+
+(type_switch_statement
+  "switch" @structure.anchor
+  "{" @structure.open
+  "}" @structure.close
+)
+
+(type_switch_statement
+  (type_case
+    "case" @structure.anchor
+    ":" @structure.open
+  )
+  .
+  [
+    (type_case "case" @structure.limit)
+    (default_case "default" @structure.limit)
+  ]
+)
+
+(select_statement
+  "select" @structure.anchor
+  "{" @structure.open
+  "}" @structure.close
+)
+
+(func_literal
+  "func" @structure.anchor
+  (block
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(for_statement
+  "for" @structure.anchor
+  (block
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(type_declaration
+  "type" @structure.anchor
+  (type_spec
+    (struct_type
+      (field_declaration_list
+        "{" @structure.open
+        "}" @structure.close
+      )
+    )
+  )
+)
+
+(struct_type
+  "struct" @structure.anchor
+  (field_declaration_list
+    "{" @structure.open
+    "}" @structure.close
+  )
+)
+
+(type_declaration
+  "type" @structure.anchor
+  (type_spec
+    (interface_type
+      "{" @structure.open
+      "}" @structure.close
+    )
+  )
+)
+
+(interface_type
+  "interface" @structure.anchor
+  "{" @structure.open
+  "}" @structure.close
+)


### PR DESCRIPTION
This introduces a "structure.scm" query definition.

I use this for two things: highlighting of related syntactic elements and indentation. The first implementation was for the highlighting only. But, as I began working on tree-sitter-backed indentation, I realized that they were almost the same underlying problem.

The query defines the following labels:

- `structure.anchor`: the beginning of a structural element
- `structure.open`: the opening of a scope
- `structure.close`: the closing of a scope
- `structure.separator`: a separator within a scope
-  `structure.limit`: the closing of scope that isn't itself part of the parent structure

I'm not sure how you might feel about something like this. But, I figured I'm using it with great success, so I might as well let you have a look. Absolutely no worries if you don't think this belongs in the parser repo. And, if you have any feedback, that would be great too!

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
