### PR TITLE
feat(queries/highlight): highlight built-in functions as @function.builtin

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,6 +1,10 @@
 ; Function calls
 
 (call_expression
+  function: (identifier) @function.builtin
+  (.match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+
+(call_expression
   function: (identifier) @function)
 
 (call_expression


### PR DESCRIPTION
This PR supersedes #61 by fixing the scoping issue it has. I have been using this query since March 10th in my own Emacs [config](https://github.com/jimeh/.emacs.d/commit/92c16d4dcbdc0401d8710dce1019dbf0dfde18f7) without any issues.

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
