### PR TITLE
Adds GH tags queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -28,3 +28,21 @@
   name: (type_identifier) @name) @definition.type
 
 (type_identifier) @name @reference.type
+
+(function_declaration name: (identifier) @name) @definition.function
+
+(type_declaration (type_spec name: (type_identifier) @name type: (struct_type))) @definition.class
+
+(type_declaration (type_spec name: (type_identifier) @name type: (interface_type))) @definition.interface
+
+(type_declaration (type_spec name: (type_identifier) @name type: [(map_type) (channel_type) (slice_type) (array_type) (pointer_type) (type_identifier)])) @definition.type
+
+(method_declaration receiver: (parameter_list (parameter_declaration type: (pointer_type (type_identifier) @scope))) name: (field_identifier) @name) @definition.method
+
+(method_declaration receiver: (parameter_list (parameter_declaration type: (type_identifier) @scope)) name: (field_identifier) @name) @definition.method
+
+(method_spec name: (field_identifier) @name) @definition.method
+
+(const_declaration (const_spec name: (identifier) @name value: (_) @definition.constant))
+
+(field_declaration name: (field_identifier) @name) @definition.field


### PR DESCRIPTION
This PR adds new tags queries to `tags.scm` to support code search on Github.com.

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
