### PR TITLE
bump tree-sitter to 0.23, hide newline tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.21.0"
+tree-sitter-language = "0.1.0"
 
 [build-dependencies]
 cc = "1.0.90"
+
+[dev-dependencies]
+tree-sitter = "0.23.0"

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,7 +3,7 @@ package tree_sitter_go_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_go "github.com/tree-sitter/tree-sitter-go/bindings/go"
 )
 

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_go
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_go.language())
+        except Exception:
+            self.fail("Error loading Go grammar")

--- a/bindings/python/tree_sitter_go/binding.c
+++ b/bindings/python/tree_sitter_go/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_go(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_go());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_go(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -12,7 +12,10 @@
 //! }
 //! "#;
 //! let mut parser = Parser::new();
-//! parser.set_language(&tree_sitter_go::language()).expect("Error loading Go grammar");
+//! let language = tree_sitter_go::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Go parser");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
@@ -22,18 +25,14 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_go() -> Language;
+    fn tree_sitter_go() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_go() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_go) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -52,7 +51,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
-            .expect("Error loading Go grammar");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Go parser");
     }
 }

--- a/bindings/swift/TreeSitterGoTests/TreeSitterGoTests.swift
+++ b/bindings/swift/TreeSitterGoTests/TreeSitterGoTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterGo
+
+final class TreeSitterGoTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_go())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Go grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/tree-sitter/tree-sitter-go
 
-go 1.22
+go 1.23
 
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8
+require github.com/tree-sitter/go-tree-sitter v0.23.1
+
+require github.com/mattn/go-pointer v0.0.1 // indirect

--- a/grammar.js
+++ b/grammar.js
@@ -25,7 +25,7 @@ const comparativeOperators = ['==', '!=', '<', '<=', '>', '>='];
 const assignmentOperators = multiplicativeOperators.concat(additiveOperators).map(operator => operator + '=').concat('=');
 
 
-const newline = '\n';
+const newline = /\n/;
 const terminator = choice(newline, ';', '\0');
 
 const hexDigit = /[0-9a-fA-F]/;

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "scripts": {
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip",
-    "build": "tree-sitter generate --no-bindings",
-    "build-wasm": "tree-sitter build --wasm",
     "lint": "eslint grammar.js",
     "parse": "tree-sitter parse",
-    "test": "tree-sitter test"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "tree-sitter": [
     {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2564,10 +2564,6 @@
     "named": false
   },
   {
-    "type": "\n",
-    "named": false
-  },
-  {
     "type": "!",
     "named": false
   },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {


### PR DESCRIPTION
This now uses `tree-sitter-language` to export the grammar, instead of relying on a cyclic dependency of itself, which caused a whole slew of issues.