### PR TITLE
Added support for generic type aliases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -259,6 +259,7 @@ module.exports = grammar({
 
     type_alias: $ => seq(
       field('name', $._type_identifier),
+      field('type_parameters', optional($.type_parameter_list)),
       '=',
       field('type', $._type),
     ),

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -467,6 +467,7 @@ type (
 	A4 = Value
 	A5 = Value
 )
+type G3[T any, C Constraint] = G4[T, string, C]
 
 --------------------------------------------------------------------------------
 
@@ -507,4 +508,25 @@ type (
       (type_identifier))
     (type_alias
       (type_identifier)
-      (type_identifier))))
+          (type_identifier)))
+      (type_declaration
+        (type_alias
+          (type_identifier)
+          (type_parameter_list
+            (type_parameter_declaration
+              (identifier)
+              (type_constraint
+                (type_identifier)))
+            (type_parameter_declaration
+              (identifier)
+              (type_constraint
+                (type_identifier))))
+          (generic_type
+            (type_identifier)
+            (type_arguments
+              (type_elem
+                (type_identifier))
+              (type_elem
+                (type_identifier))
+              (type_elem
+                (type_identifier)))))))


### PR DESCRIPTION
Support for generic type aliased were added in Go 1.24
https://tip.golang.org/doc/go1.24
https://github.com/golang/go/issues/46477
https://tip.golang.org/ref/spec#Alias_declarations

