### PR TITLE
Move Identifiers over Functions

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,3 +1,9 @@
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
 ; Function calls
 
 (call_expression
@@ -18,12 +24,6 @@
 
 (method_declaration
   name: (field_identifier) @function.method)
-
-; Identifiers
-
-(type_identifier) @type
-(field_identifier) @property
-(identifier) @variable
 
 ; Operators
 


### PR DESCRIPTION
I just wondering, if there's a different way to solve it? My functions are highlighted in the Variables color. And changing the order, such as moving the Identifiers block above a block of Function, does this well.

Before (now):
<img width="368" height="241" alt="image" src="https://github.com/user-attachments/assets/1ab4f23c-48da-46dd-a9a6-6c37c802340c" />

After (PR):
<img width="368" height="240" alt="image" src="https://github.com/user-attachments/assets/697ee40b-fa85-4299-b2b5-99915c53e223" />
